### PR TITLE
Migrate from Chat Completions to Responses API

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -10,6 +10,8 @@ services:
     project: ./src
     language: py
     host: containerapp
+    docker:
+      remoteBuild: true
 hooks:
     postprovision:
       windows:

--- a/infra/aca.bicep
+++ b/infra/aca.bicep
@@ -41,7 +41,7 @@ module app 'core/host/container-app-upsert.bicep' = {
         value: 'true'
       }
       {
-        name: 'AZURE_OPENAI_CLIENT_ID'
+        name: 'AZURE_CLIENT_ID'
         value: acaIdentity.properties.clientId
       }
       {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -20,7 +20,7 @@ param allowedOrigins string = ''
 
 param openAiResourceName string = ''
 param openAiResourceGroupName string = ''
-@description('Location for the OpenAI resource group')
+@description('Location for the OpenAI resource group. See https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure for model availability by location.')
 @allowed([ 'canadaeast', 'eastus', 'eastus2', 'francecentral', 'switzerlandnorth', 'uksouth', 'japaneast', 'northcentralus', 'australiaeast', 'swedencentral' ])
 @metadata({
   azd: {
@@ -65,11 +65,11 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
         name: openAiDeploymentName
         model: {
           format: 'OpenAI'
-          name: 'gpt-35-turbo'
-          version: '0613'
+          name: 'gpt-5.2'
+          version: '2025-12-11'
         }
         sku: {
-          name: 'Standard'
+          name: 'GlobalStandard'
           capacity: openAiDeploymentCapacity
         }
       }

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -30,9 +30,9 @@ async def lifespan(app: fastapi.FastAPI):
             # that want to develop locally inside the Docker container.
             client_args["api_key"] = os.getenv("AZURE_OPENAI_KEY")
         else:
-            if client_id := os.getenv("AZURE_OPENAI_CLIENT_ID"):
+            if client_id := os.getenv("AZURE_CLIENT_ID"):
                 # Authenticate using a user-assigned managed identity on Azure
-                # See aca.bicep for value of AZURE_OPENAI_CLIENT_ID
+                # See aca.bicep for value of AZURE_CLIENT_ID
                 default_credential = azure.identity.aio.ManagedIdentityCredential(client_id=client_id)
             else:
                 # Authenticate using the default Azure credential chain
@@ -41,12 +41,11 @@ async def lifespan(app: fastapi.FastAPI):
                 default_credential = azure.identity.aio.DefaultAzureCredential(
                     exclude_shared_token_cache_credential=True
                 )
-            client_args["azure_ad_token_provider"] = azure.identity.aio.get_bearer_token_provider(
+            client_args["api_key"] = azure.identity.aio.get_bearer_token_provider(
                 default_credential, "https://cognitiveservices.azure.com/.default"
             )
-        clients["openai"] = openai.AsyncAzureOpenAI(
-            api_version="2023-07-01-preview",
-            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+        clients["openai"] = openai.AsyncOpenAI(
+            base_url=f"{os.getenv('AZURE_OPENAI_ENDPOINT', '').rstrip('/')}/openai/v1/",
             **client_args,
         )
 

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -27,13 +27,12 @@ async def chat_handler(chat_request: ChatRequest) -> dict:
     # Azure Open AI takes the deployment name as the model name
     model = os.getenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "chatgpt")
 
-    response = await clients["openai"].chat.completions.create(
+    response = await clients["openai"].responses.create(
         model=model,
-        messages=messages,
-        stream=False,
+        input=messages,
+        store=False,
     )
-    first_choice = response.model_dump()["choices"][0]
-    return {"message": first_choice["message"]}
+    return {"message": {"content": response.output_text, "role": "assistant"}}
 
 
 @router.post("/chat/stream")
@@ -43,14 +42,19 @@ async def chat_stream_handler(chat_request: ChatRequest) -> fastapi.responses.St
     model = os.getenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "chatgpt")
 
     async def response_stream():
-        chat_coroutine = clients["openai"].chat.completions.create(
+        chat_coroutine = clients["openai"].responses.create(
             model=model,
-            messages=messages,
+            input=messages,
             stream=True,
+            store=False,
         )
-        async for event in await chat_coroutine:
-            if event.choices:
-                first_choice = event.model_dump()["choices"][0]
-                yield json.dumps({"delta": first_choice["delta"]}, ensure_ascii=False) + "\n"
+        try:
+            async for event in await chat_coroutine:
+                if event.type == "response.output_text.delta":
+                    yield json.dumps({"delta": {"content": event.delta}}, ensure_ascii=False) + "\n"
+                elif event.type == "response.completed":
+                    yield json.dumps({"delta": {"content": None}, "finish_reason": "stop"}, ensure_ascii=False) + "\n"
+        except Exception as e:
+            yield json.dumps({"error": str(e)}) + "\n"
 
     return fastapi.responses.StreamingResponse(response_stream())

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.111.0
 uvicorn[standard]==0.30.1
 gunicorn==22.0.0
-openai>=1.47.0
+openai>=1.108.1
 azure-identity==1.16.1
 python-dotenv # Pinned due to docker-in-docker issue: https://github.com/devcontainers/features/issues/616
 environs==11.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import azure.core.credentials_async
-import openai
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
@@ -8,132 +7,43 @@ from src import api
 
 
 @pytest.fixture
-def mock_openai_chatcompletion(monkeypatch):
-    class AsyncChatCompletionIterator:
-        def __init__(self, answer: str):
-            self.chunk_index = 0
-            self.chunks = [
-                # This is an Azure-specific chunk solely for prompt_filter_results
-                openai.types.chat.ChatCompletionChunk(
-                    object="chat.completion.chunk",
-                    choices=[],
-                    id="",
-                    created=0,
-                    model="",
-                    prompt_filter_results=[
-                        {
-                            "prompt_index": 0,
-                            "content_filter_results": {
-                                "hate": {"filtered": False, "severity": "safe"},
-                                "self_harm": {"filtered": False, "severity": "safe"},
-                                "sexual": {"filtered": False, "severity": "safe"},
-                                "violence": {"filtered": False, "severity": "safe"},
-                            },
-                        }
-                    ],
-                ),
-                openai.types.chat.ChatCompletionChunk(
-                    id="test-123",
-                    object="chat.completion.chunk",
-                    choices=[
-                        openai.types.chat.chat_completion_chunk.Choice(
-                            delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(content=None, role="assistant"),
-                            index=0,
-                            finish_reason=None,
-                            # Only Azure includes content_filter_results
-                            content_filter_results={},
-                        )
-                    ],
-                    created=1703462735,
-                    model="gpt-35-turbo",
-                ),
-            ]
-            answer_deltas = answer.split(" ")
-            for answer_index, answer_delta in enumerate(answer_deltas):
-                # Completion chunks include whitespace, so we need to add it back in
-                if answer_index > 0:
-                    answer_delta = " " + answer_delta
-                self.chunks.append(
-                    openai.types.chat.ChatCompletionChunk(
-                        id="test-123",
-                        object="chat.completion.chunk",
-                        choices=[
-                            openai.types.chat.chat_completion_chunk.Choice(
-                                delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(
-                                    role=None, content=answer_delta
-                                ),
-                                finish_reason=None,
-                                index=0,
-                                logprobs=None,
-                                # Only Azure includes content_filter_results
-                                content_filter_results={
-                                    "hate": {"filtered": False, "severity": "safe"},
-                                    "self_harm": {"filtered": False, "severity": "safe"},
-                                    "sexual": {"filtered": False, "severity": "safe"},
-                                    "violence": {"filtered": False, "severity": "safe"},
-                                },
-                            )
-                        ],
-                        created=1703462735,
-                        model="gpt-35-turbo",
-                    )
-                )
-            self.chunks.append(
-                openai.types.chat.ChatCompletionChunk(
-                    id="test-123",
-                    object="chat.completion.chunk",
-                    choices=[
-                        openai.types.chat.chat_completion_chunk.Choice(
-                            delta=openai.types.chat.chat_completion_chunk.ChoiceDelta(content=None, role=None),
-                            index=0,
-                            finish_reason="stop",
-                            # Only Azure includes content_filter_results
-                            content_filter_results={},
-                        )
-                    ],
-                    created=1703462735,
-                    model="gpt-35-turbo",
-                )
-            )
+def mock_openai_responses(monkeypatch):
+    class MockResponseEvent:
+        def __init__(self, event_type, delta=None):
+            self.type = event_type
+            self.delta = delta
+
+    class AsyncResponseIterator:
+        def __init__(self, answer):
+            self.event_index = 0
+            self.events = []
+            for i, word in enumerate(answer.split(" ")):
+                if i > 0:
+                    word = " " + word
+                self.events.append(MockResponseEvent("response.output_text.delta", delta=word))
+            self.events.append(MockResponseEvent("response.completed"))
 
         def __aiter__(self):
             return self
 
         async def __anext__(self):
-            if self.chunk_index < len(self.chunks):
-                next_chunk = self.chunks[self.chunk_index]
-                self.chunk_index += 1
-                return next_chunk
-            else:
-                raise StopAsyncIteration
+            if self.event_index < len(self.events):
+                event = self.events[self.event_index]
+                self.event_index += 1
+                return event
+            raise StopAsyncIteration
+
+    class MockResponse:
+        def __init__(self, output_text):
+            self.output_text = output_text
 
     async def mock_acreate(*args, **kwargs):
         if kwargs.get("stream"):
-            return AsyncChatCompletionIterator("The capital of France is Paris.")
+            return AsyncResponseIterator("The capital of France is Paris.")
         else:
-            return openai.types.chat.ChatCompletion(
-                object="chat.completion",
-                choices=[
-                    openai.types.chat.chat_completion.Choice(
-                        message=openai.types.chat.chat_completion.ChatCompletionMessage(
-                            role="assistant", content="The capital of France is Paris."
-                        ),
-                        finish_reason="stop",
-                        index=0,
-                        logprobs=None,
-                    )
-                ],
-                id="test-123",
-                created=0,
-                model="test-model",
-                usage=openai.types.completion_usage.CompletionUsage(
-                    completion_tokens=7,
-                    prompt_tokens=24,
-                    total_tokens=31,
-                ),
-            )
+            return MockResponse("The capital of France is Paris.")
 
-    monkeypatch.setattr("openai.resources.chat.AsyncCompletions.create", mock_acreate)
+    monkeypatch.setattr("openai.resources.responses.AsyncResponses.create", mock_acreate)
 
 
 @pytest.fixture
@@ -146,7 +56,7 @@ def mock_azure_credentials(monkeypatch):
 
 
 @pytest_asyncio.fixture
-async def client(monkeypatch, mock_openai_chatcompletion, mock_azure_credentials):
+async def client(monkeypatch, mock_openai_responses, mock_azure_credentials):
     monkeypatch.setenv("AZURE_OPENAI_KEY", "")
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "test-openai-service.openai.azure.com")
     monkeypatch.setenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "test-chatgpt")

--- a/tests/snapshots/test_app/test_chat_nostream/result.json
+++ b/tests/snapshots/test_app/test_chat_nostream/result.json
@@ -1,11 +1,6 @@
 {
     "message": {
         "content": "The capital of France is Paris.",
-        "refusal": null,
-        "role": "assistant",
-        "annotations": null,
-        "audio": null,
-        "function_call": null,
-        "tool_calls": null
+        "role": "assistant"
     }
 }

--- a/tests/snapshots/test_app/test_chat_stream/result.jsonlines
+++ b/tests/snapshots/test_app/test_chat_stream/result.jsonlines
@@ -1,8 +1,7 @@
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": "assistant", "tool_calls": null}}
-{"delta": {"content": "The", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": " capital", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": " of", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": " France", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": " is", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": " Paris.", "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
-{"delta": {"content": null, "function_call": null, "refusal": null, "role": null, "tool_calls": null}}
+{"delta": {"content": "The"}}
+{"delta": {"content": " capital"}}
+{"delta": {"content": " of"}}
+{"delta": {"content": " France"}}
+{"delta": {"content": " is"}}
+{"delta": {"content": " Paris."}}
+{"delta": {"content": null}, "finish_reason": "stop"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,12 +1,13 @@
 import json
 
+import openai
 import pytest
 from fastapi.testclient import TestClient
 
 from src import api
 
 
-def test_chat_stream(client, mock_openai_chatcompletion, snapshot):
+def test_chat_stream(client, mock_openai_responses, snapshot):
     response = client.post(
         "/chat/stream",
         json={"messages": [{"content": "What is the capital of France?", "role": "user"}]},
@@ -15,7 +16,7 @@ def test_chat_stream(client, mock_openai_chatcompletion, snapshot):
     snapshot.assert_match(response.content, "result.jsonlines")
 
 
-def test_chat_nostream(client, mock_openai_chatcompletion, snapshot):
+def test_chat_nostream(client, mock_openai_responses, snapshot):
     response = client.post(
         "/chat",
         json={"messages": [{"content": "What is the capital of France?", "role": "user"}], "stream": False},
@@ -39,27 +40,29 @@ async def test_openai_azure_key(monkeypatch, mock_azure_credentials):
 @pytest.mark.asyncio
 async def test_openai_azure_defaultcredential(monkeypatch, mock_azure_credentials):
     monkeypatch.setenv("AZURE_OPENAI_KEY", "")
-    monkeypatch.setenv("AZURE_OPENAI_CLIENT_ID", "")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "")
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "test-openai-service.openai.azure.com")
     monkeypatch.setenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "test-chatgpt")
 
     fastapi_app = api.create_app()
 
     with TestClient(fastapi_app):
-        assert api.globals.clients["openai"]._azure_ad_token_provider is not None
+        assert isinstance(api.globals.clients["openai"], openai.AsyncOpenAI)
+        assert "/openai/v1/" in str(api.globals.clients["openai"].base_url)
 
 
 @pytest.mark.asyncio
 async def test_openai_azure_managedidentity(monkeypatch, mock_azure_credentials):
     monkeypatch.setenv("AZURE_OPENAI_KEY", "")
-    monkeypatch.setenv("AZURE_OPENAI_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("AZURE_OPENAI_ENDPOINT", "test-openai-service.openai.azure.com")
     monkeypatch.setenv("AZURE_OPENAI_CHATGPT_DEPLOYMENT", "test-chatgpt")
 
     fastapi_app = api.create_app()
 
     with TestClient(fastapi_app):
-        assert api.globals.clients["openai"]._azure_ad_token_provider is not None
+        assert isinstance(api.globals.clients["openai"], openai.AsyncOpenAI)
+        assert "/openai/v1/" in str(api.globals.clients["openai"].base_url)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Migrates the app from Azure OpenAI Chat Completions API to the Responses API, enabling compatibility with newer models (gpt-5.2).

## Changes

### Python code
- **Client**: Replace `AsyncAzureOpenAI` with `AsyncOpenAI` using the `/openai/v1/` base URL endpoint
- **Chat endpoint**: Switch from `chat.completions.create(messages=...)` to `responses.create(input=..., store=False)`
- **Streaming**: Update from `ChatCompletionChunk` delta handling to `response.output_text.delta` / `response.completed` events
- **Auth**: Unchanged — still supports API key, managed identity, and DefaultAzureCredential via the `api_key` parameter

### Infrastructure (Bicep)
- **Model**: Upgrade from deprecated `gpt-35-turbo` (0613) to `gpt-5.2` (2025-12-11)
- **SKU**: Change from `Standard` to `GlobalStandard` (required by gpt-5.2)
- **Docs**: Add model availability link to `openAiResourceLocation` parameter description

### Dependencies
- Bump `openai` requirement to `>=1.108.1`

### Tests
- Update mocks to use `openai.resources.responses.AsyncResponses.create`
- Update mock classes to emit Responses API event types
- Refresh test snapshots
